### PR TITLE
Test suite prototyping for collectAsArrow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1883,6 +1883,25 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-tools</artifactId>
+        <version>${arrow.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -96,6 +96,10 @@
       <artifactId>arrow-vector</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-tools</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2536,8 +2536,8 @@ class Dataset[T] private[sql](
    * @since 2.2.0
    */
   @DeveloperApi
-  def collectAsArrow(): ArrowRecordBatch = {
-    val allocator = new RootAllocator(Long.MaxValue)
+  def collectAsArrow(
+      allocator: RootAllocator = new RootAllocator(Long.MaxValue)): ArrowRecordBatch = {
     withNewExecutionId {
       try {
         val collectedRows = queryExecution.executedPlan.executeCollect()

--- a/sql/core/src/test/resources/test-data/arrowNullInts.json
+++ b/sql/core/src/test/resources/test-data/arrowNullInts.json
@@ -1,0 +1,31 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "a",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+    "batches": [
+        {
+            "count": 4,
+            "columns": [
+                {
+                    "name": "a",
+                    "count": 4,
+                    "VALIDITY": [1, 1, 1, 0],
+                    "DATA": [1, 2, 3, 0]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/ArrowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ArrowSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import java.io.File
+
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.tools.Integration
+import org.apache.arrow.vector.{VectorLoader, VectorSchemaRoot}
+import org.apache.arrow.vector.file.json.JsonFileReader
+
+import org.apache.spark.sql.test.{SharedSQLContext, SQLTestUtils}
+
+class ArrowSuite extends QueryTest with SharedSQLContext with SQLTestUtils {
+  import testImplicits._
+  private val nullIntsFile = "test-data/arrowNullInts.json"
+
+  private def testFile(fileName: String): String = {
+    // TODO: Copied from CSVSuite, find a better way to read test files
+    Thread.currentThread().getContextClassLoader.getResource(fileName).toString.substring(5)
+  }
+
+  test("convert int column with null to arrow") {
+    val df = nullInts
+    val jsonFilePath = testFile(nullIntsFile)
+
+    val allocator = new RootAllocator(Integer.MAX_VALUE)
+    val jsonReader = new JsonFileReader(new File(jsonFilePath), allocator)
+
+    val arrowSchema = df.schemaToArrowSchema(df.schema)
+    val jsonSchema = jsonReader.start()
+    Integration.compareSchemas(arrowSchema, jsonSchema)
+
+    val arrowRecordBatch = df.collectAsArrow(allocator)
+    val arrowRoot = new VectorSchemaRoot(arrowSchema, allocator)
+    val vectorLoader = new VectorLoader(arrowRoot)
+    vectorLoader.load(arrowRecordBatch)
+    val jsonRoot = jsonReader.read()
+
+    Integration.compare(arrowRoot, jsonRoot)
+  }
+}


### PR DESCRIPTION
@BryanCutler @icexelloss started this patch, but is out for the holidays for a couple of weeks. If this is useful for starting a test suite for record batch conversion feel free to pull it into the integration branch.

This ideally needs ARROW-411 -- temporarily this adds arrow-tools as a dependency to get access to functions in the integration tester.

cc @leifwalsh