### PR TITLE
Stc to pandas with arrow

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -2098,6 +2098,15 @@ class ArrowTests(ReusedPySparkTestCase):
     def setUpClass(cls):
         ReusedPySparkTestCase.setUpClass()
         cls.spark = SparkSession(cls.sc)
+        cls.schema = StructType([
+            StructField("str_t", StringType(), True),
+            StructField("int_t", IntegerType(), True),
+            StructField("long_t", LongType(), True),
+            StructField("float_t", FloatType(), True),
+            StructField("double_t", DoubleType(), True)])
+        cls.data = [("a", 1, 10, 0.2, 2.0),
+                    ("b", 2, 20, 0.4, 4.0),
+                    ("c", 3, 30, 0.8, 6.0)]
 
     def assertFramesEqual(self, df_with_arrow, df_without):
         msg = ("DataFrame from Arrow is not equal" +
@@ -2105,20 +2114,27 @@ class ArrowTests(ReusedPySparkTestCase):
                ("\n\nWithout:\n%s\n%s" % (df_without, df_without.dtypes)))
         self.assertTrue(df_without.equals(df_with_arrow), msg=msg)
 
-    def test_arrow_toPandas(self):
-        schema = StructType([
-            StructField("str_t", StringType(), True),  # Fails in conversion
-            StructField("int_t", IntegerType(), True),  # Fails, without is converted to int64
-            StructField("long_t", LongType(), True),  # Fails if nullable=False
-            StructField("double_t", DoubleType(), True)])
-        data = [("a", 1, 10, 2.0),
-                ("b", 2, 20, 4.0),
-                ("c", 3, 30, 6.0)]
+    def test_null_conversion(self):
+        df_null = self.spark.createDataFrame([tuple([None for _ in range(len(self.data[0]))])] +
+                                             self.data)
+        pdf = df_null.toPandas(useArrow=True)
+        null_counts = pdf.isnull().sum().tolist()
+        self.assertTrue(all([c == 1 for c in null_counts]))
 
-        df = self.spark.createDataFrame(data, schema=schema)
-        df = df.select("long_t", "double_t")
-        pdf = df.toPandas(useArrow=False)
-        pdf_arrow = df.toPandas(useArrow=True)
+    def test_toPandas_arrow_toggle(self):
+        df = self.spark.createDataFrame(self.data, schema=self.schema)
+        # NOTE - toPandas(useArrow=False) will infer standard data types
+        df_sel = df.select("str_t", "long_t", "double_t")
+        pdf = df_sel.toPandas(useArrow=False)
+        pdf_arrow = df_sel.toPandas(useArrow=True)
+        self.assertFramesEqual(pdf_arrow, pdf)
+
+    def test_pandas_round_trip(self):
+        import pandas as pd
+        data_dict = {name: [self.data[i][j] for i in range(len(self.data))]
+                     for j, name in enumerate(self.schema.names)}
+        pdf = pd.DataFrame(data=data_dict)
+        pdf_arrow = self.spark.createDataFrame(pdf).toPandas(useArrow=True)
         self.assertFramesEqual(pdf_arrow, pdf)
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Arrow.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Arrow.scala
@@ -53,7 +53,7 @@ object Arrow {
             buf.writeBoolean(row.getBoolean(ordinal)))
       case ShortType =>
         TypeFuncs(
-          () => new ArrowType.Int(4 * ShortType.defaultSize, true), // TODO - check on this
+          () => new ArrowType.Int(8 * ShortType.defaultSize, true),
           (buf: ArrowBuf) => buf.writeShort(0),
           (row: InternalRow, ordinal: Int, buf: ArrowBuf) => buf.writeShort(row.getShort(ordinal)))
       case IntegerType =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/Arrow.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Arrow.scala
@@ -127,7 +127,7 @@ object Arrow {
     val numOfRows = rows.length
 
     field.dataType match {
-      case IntegerType | LongType | DoubleType | FloatType | BooleanType | ByteType =>
+      case ShortType | IntegerType | LongType | DoubleType | FloatType | BooleanType | ByteType =>
         val validityVector = new BitVector("validity", allocator)
         val validityMutator = validityVector.getMutator
         validityVector.allocateNew(numOfRows)

--- a/sql/core/src/test/resources/test-data/arrow/decimalData-BigDecimal.json
+++ b/sql/core/src/test/resources/test-data/arrow/decimalData-BigDecimal.json
@@ -1,0 +1,50 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "a",
+                "type": {"name": "floatingpoint", "precision": "DOUBLE"},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b",
+                "type": {"name": "floatingpoint", "precision": "DOUBLE"},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "a",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 1, 2, 2, 3, 3]
+                },
+                {
+                    "name": "b",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 1, 2, 1, 2]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/doubleData-double_precision-nullable.json
+++ b/sql/core/src/test/resources/test-data/arrow/doubleData-double_precision-nullable.json
@@ -1,0 +1,68 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            },
+            {
+                "name": "a_d",
+                "type": {"name": "floatingpoint", "precision": "DOUBLE"},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b_d",
+                "type": {"name": "floatingpoint", "precision": "DOUBLE"},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "i",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 3, 4, 5, 6]
+                },
+                {
+                    "name": "a_d",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1.0, 2.0, 0.01, 200.0, 0.0001, 20000.0]
+                },
+                {
+                    "name": "b_d",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1.1, 0, 0, 2.2, 0, 3.3]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/floatData-single_precision-nullable.json
+++ b/sql/core/src/test/resources/test-data/arrow/floatData-single_precision-nullable.json
@@ -2,9 +2,21 @@
     "schema": {
         "fields": [
             {
-                "name": "a",
+                "name": "i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            },
+            {
+                "name": "a_f",
                 "type": {"name": "floatingpoint", "precision": "SINGLE"},
-                "nullable": true,
+                "nullable": false,
                 "children": [],
                 "typeLayout": {
                     "vectors": [
@@ -14,9 +26,9 @@
                 }
             },
             {
-                "name": "b",
+                "name": "b_f",
                 "type": {"name": "floatingpoint", "precision": "SINGLE"},
-                "nullable": false,
+                "nullable": true,
                 "children": [],
                 "typeLayout": {
                     "vectors": [
@@ -33,16 +45,22 @@
             "count": 6,
             "columns": [
                 {
-                    "name": "a",
+                    "name": "i",
                     "count": 6,
-                    "VALIDITY": [1, 0, 0, 1, 0, 1],
-                    "DATA": [1.0, 0, 0, 2.0, 0, 3.0]
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 3, 4, 5, 6]
                 },
                 {
-                    "name": "b",
+                    "name": "a_f",
                     "count": 6,
                     "VALIDITY": [1, 1, 1, 1, 1, 1],
                     "DATA": [1.0, 2.0, 0.01, 200.0, 0.0001, 20000.0]
+                },
+                {
+                    "name": "b_f",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1.1, 0, 0, 2.2, 0, 3.3]
                 }
             ]
         }

--- a/sql/core/src/test/resources/test-data/arrow/floatData-single_precision.json
+++ b/sql/core/src/test/resources/test-data/arrow/floatData-single_precision.json
@@ -1,0 +1,50 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "a",
+                "type": {"name": "floatingpoint", "precision": "SINGLE"},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b",
+                "type": {"name": "floatingpoint", "precision": "SINGLE"},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "a",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1.0, 0, 0, 2.0, 0, 3.0]
+                },
+                {
+                    "name": "b",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1.0, 2.0, 0.01, 200.0, 0.0001, 20000.0]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/indexData-ints.json
+++ b/sql/core/src/test/resources/test-data/arrow/indexData-ints.json
@@ -1,0 +1,32 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "i",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 3, 4, 5, 6]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/intData-32bit_ints-nullable.json
+++ b/sql/core/src/test/resources/test-data/arrow/intData-32bit_ints-nullable.json
@@ -1,0 +1,68 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            },
+            {
+                "name": "a_i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b_i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "i",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 3, 4, 5, 6]
+                },
+                {
+                    "name": "a_i",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, -1, 2, -2, 2147483647, -2147483648]
+                },
+                {
+                    "name": "b_i",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1, -1, 2, -2, 2147483647, -2147483648]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/largeAndSmall-ints.json
+++ b/sql/core/src/test/resources/test-data/arrow/largeAndSmall-ints.json
@@ -1,0 +1,50 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "a",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "a",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [2147483644, 1, 2147483645, 2, 2147483646, 3]
+                },
+                {
+                    "name": "b",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 1, 2, 1, 2]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/longData-64bit_ints-nullable.json
+++ b/sql/core/src/test/resources/test-data/arrow/longData-64bit_ints-nullable.json
@@ -1,0 +1,68 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            },
+            {
+                "name": "a_l",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 64},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b_l",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 64},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "i",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 3, 4, 5, 6]
+                },
+                {
+                    "name": "a_l",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, -1, 2, -2, 9223372036854775807, -9223372036854775808]
+                },
+                {
+                    "name": "b_l",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1, -1, 2, -2, 9223372036854775807, -9223372036854775808]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/lowercase-strings.json
+++ b/sql/core/src/test/resources/test-data/arrow/lowercase-strings.json
@@ -1,0 +1,52 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "n",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            },
+            {
+                "name": "l",
+                "type": {"name": "utf8"},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "OFFSET", "typeBitWidth": 32},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 4,
+            "columns": [
+                {
+                    "name": "n",
+                    "count": 4,
+                    "VALIDITY": [1, 1, 1, 1],
+                    "DATA": [1, 2, 3, 4]
+                },
+                {
+                    "name": "l",
+                    "count": 4,
+                    "VALIDITY": [1, 1, 1, 1],
+                    "OFFSET": [0, 1, 2, 3, 4],
+                    "DATA": ["a", "b", "c", "d"]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/mixedData-standard-nullable.json
+++ b/sql/core/src/test/resources/test-data/arrow/mixedData-standard-nullable.json
@@ -1,0 +1,212 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            },
+            {
+                "name": "a_s",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 16},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b_s",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 16},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "a_i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b_i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "a_l",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 64},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b_l",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 64},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "a_f",
+                "type": {"name": "floatingpoint", "precision": "SINGLE"},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b_f",
+                "type": {"name": "floatingpoint", "precision": "SINGLE"},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "a_d",
+                "type": {"name": "floatingpoint", "precision": "DOUBLE"},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b_d",
+                "type": {"name": "floatingpoint", "precision": "DOUBLE"},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "i",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 3, 4, 5, 6]
+                },
+                {
+                    "name": "a_s",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, -1, 2, -2, 32767, -32768]
+                },
+                {
+                    "name": "b_s",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1, -1, 2, -2, 32767, -32768]
+                },
+                {
+                    "name": "a_i",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, -1, 2, -2, 2147483647, -2147483648]
+                },
+                {
+                    "name": "b_i",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1, -1, 2, -2, 2147483647, -2147483648]
+                },
+                {
+                    "name": "a_l",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, -1, 2, -2, 9223372036854775807, -9223372036854775808]
+                },
+                {
+                    "name": "b_l",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1, -1, 2, -2, 9223372036854775807, -9223372036854775808]
+                },
+                {
+                    "name": "a_f",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1.0, 2.0, 0.01, 200.0, 0.0001, 20000.0]
+                },
+                {
+                    "name": "b_f",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1.1, 0, 0, 2.2, 0, 3.3]
+                },
+                {
+                    "name": "a_d",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1.0, 2.0, 0.01, 200.0, 0.0001, 20000.0]
+                },
+                {
+                    "name": "b_d",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1.1, 0, 0, 2.2, 0, 3.3]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/null-ints-mixed.json
+++ b/sql/core/src/test/resources/test-data/arrow/null-ints-mixed.json
@@ -1,0 +1,50 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "a",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 2,
+            "columns": [
+                {
+                    "name": "a",
+                    "count": 2,
+                    "VALIDITY": [1, 1],
+                    "DATA": [1, 2]
+                },
+                {
+                    "name": "b",
+                    "count": 2,
+                    "VALIDITY": [0, 1],
+                    "DATA": [0, 2]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/salary-doubles.json
+++ b/sql/core/src/test/resources/test-data/arrow/salary-doubles.json
@@ -1,0 +1,50 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "personId",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "salary",
+                "type": {"name": "floatingpoint", "precision": "DOUBLE"},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 2,
+            "columns": [
+                {
+                    "name": "personId",
+                    "count": 2,
+                    "VALIDITY": [1, 1],
+                    "DATA": [0, 1]
+                },
+                {
+                    "name": "salary",
+                    "count": 2,
+                    "VALIDITY": [1, 1],
+                    "DATA": [2000.0, 1000.0]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/shortData-16bit_ints-nullable.json
+++ b/sql/core/src/test/resources/test-data/arrow/shortData-16bit_ints-nullable.json
@@ -1,0 +1,68 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "i",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            },
+            {
+                "name": "a_s",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 16},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b_s",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 16},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "i",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 3, 4, 5, 6]
+                },
+                {
+                    "name": "a_s",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, -1, 2, -2, 32767, -32768]
+                },
+                {
+                    "name": "b_s",
+                    "count": 6,
+                    "VALIDITY": [1, 0, 0, 1, 0, 1],
+                    "DATA": [1, -1, 2, -2, 32767, -32768]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/testData2-ints.json
+++ b/sql/core/src/test/resources/test-data/arrow/testData2-ints.json
@@ -1,0 +1,50 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "a",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "a",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 1, 2, 2, 3, 3]
+                },
+                {
+                    "name": "b",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 1, 2, 1, 2]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/uppercase-strings.json
+++ b/sql/core/src/test/resources/test-data/arrow/uppercase-strings.json
@@ -1,0 +1,52 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "N",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            },
+            {
+                "name": "L",
+                "type": {"name": "utf8"},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "OFFSET", "typeBitWidth": 32},
+                        {"type": "DATA", "typeBitWidth": 8}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 6,
+            "columns": [
+                {
+                    "name": "N",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "DATA": [1, 2, 3, 4, 5, 6]
+                },
+                {
+                    "name": "L",
+                    "count": 6,
+                    "VALIDITY": [1, 1, 1, 1, 1, 1],
+                    "OFFSET": [0, 1, 2, 3, 4, 5, 6],
+                    "DATA": ["A", "B", "C", "D", "E", "F"]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/ArrowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ArrowSuite.scala
@@ -22,26 +22,77 @@ import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.{VectorLoader, VectorSchemaRoot}
 import org.apache.arrow.vector.file.json.JsonFileReader
 import org.apache.arrow.vector.util.Validator
-
 import org.apache.spark.sql.test.SharedSQLContext
 
+
+private[sql] case class FloatData(a: Option[Float], b: Float)
+
 class ArrowSuite extends SharedSQLContext {
+  import testImplicits._
 
   private def testFile(fileName: String): String = {
     Thread.currentThread().getContextClassLoader.getResource(fileName).getFile
   }
 
+  test("collect to arrow record batch") {
+    val data = Seq(1, 2, 3, 4, 5, 6).toDF()
+    val arrowRecordBatch = data.collectAsArrow()
+    assert(arrowRecordBatch.getLength > 0)
+    assert(arrowRecordBatch.getNodes.size() > 0)
+    arrowRecordBatch.close()
+  }
+
+  test("standard type conversion") {
+    collectAndValidate(largeAndSmallInts, "test-data/arrow/largeAndSmall-ints.json")
+    collectAndValidate(floatData, "test-data/arrow/floatData-single_precision.json")
+    collectAndValidate(salary, "test-data/arrow/salary-doubles.json")
+  }
+
+  test("partitioned DataFrame") {
+    collectAndValidate(testData2, "test-data/arrow/testData2-ints.json")
+  }
+
+  test("string type conversion") {
+    collectAndValidate(upperCaseData, "test-data/arrow/uppercase-strings.json")
+    collectAndValidate(lowerCaseData, "test-data/arrow/lowercase-strings.json")
+  }
+
+  test("time and date conversion") { }
+
+  test("nested type conversion") { }
+
+  test("array type conversion") {
+
+  }
+
+  test("mapped type conversion") { }
+
+  test("other type conversion") {
+    // byte type, or binary
+    // allNulls
+
+  }
+
+  ignore("arbitrary precision floating point") {
+    collectAndValidate(decimalData, "test-data/arrow/decimalData-BigDecimal.json")
+  }
+
+  test("other null conversion") { }
+
   test("convert int column with null to arrow") {
-    testCollect(nullInts, "test-data/arrow/null-ints.json")
+    collectAndValidate(nullInts, "test-data/arrow/null-ints.json")
+    collectAndValidate(testData3, "test-data/arrow/null-ints-mixed.json")
   }
 
   test("convert string column with null to arrow") {
     val nullStringsColOnly = nullStrings.select(nullStrings.columns(1))
-    testCollect(nullStringsColOnly, "test-data/arrow/null-strings.json")
+    collectAndValidate(nullStringsColOnly, "test-data/arrow/null-strings.json")
   }
 
+  test("negative tests") { }
+
   /** Test that a converted DataFrame to Arrow record batch equals batch read from JSON file */
-  private def testCollect(df: DataFrame, arrowFile: String) {
+  private def collectAndValidate(df: DataFrame, arrowFile: String) {
     val jsonFilePath = testFile(arrowFile)
 
     val allocator = new RootAllocator(Integer.MAX_VALUE)
@@ -58,5 +109,15 @@ class ArrowSuite extends SharedSQLContext {
     val jsonRoot = jsonReader.read()
 
     Validator.compareVectorSchemaRoot(arrowRoot, jsonRoot)
+  }
+
+  protected lazy val floatData: DataFrame = {
+    spark.sparkContext.parallelize(
+      FloatData(Some(1), 1.0f) ::
+      FloatData(None, 2.0f) ::
+      FloatData(None, 0.01f) ::
+      FloatData(Some(2), 200.0f) ::
+      FloatData(None, 0.0001f) ::
+      FloatData(Some(3), 20000.0f) :: Nil).toDF()
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ArrowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ArrowSuite.scala
@@ -22,6 +22,7 @@ import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.{VectorLoader, VectorSchemaRoot}
 import org.apache.arrow.vector.file.json.JsonFileReader
 import org.apache.arrow.vector.util.Validator
+
 import org.apache.spark.sql.test.SharedSQLContext
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ArrowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ArrowSuite.scala
@@ -25,7 +25,13 @@ import org.apache.arrow.vector.util.Validator
 import org.apache.spark.sql.test.SharedSQLContext
 
 
-private[sql] case class FloatData(a: Option[Float], b: Float)
+// NOTE - nullable type can be declared as Option[*] or java.lang.*
+private[sql] case class ShortData(i: Int, a_s: Short, b_s: Option[Short])
+private[sql] case class IntData(i: Int, a_i: Int, b_i: Option[Int])
+private[sql] case class LongData(i: Int, a_l: Long, b_l: java.lang.Long)
+private[sql] case class FloatData(i: Int, a_f: Float, b_f: Option[Float])
+private[sql] case class DoubleData(i: Int, a_d: Double, b_d: Option[Double])
+
 
 class ArrowSuite extends SharedSQLContext {
   import testImplicits._
@@ -35,17 +41,30 @@ class ArrowSuite extends SharedSQLContext {
   }
 
   test("collect to arrow record batch") {
-    val data = Seq(1, 2, 3, 4, 5, 6).toDF()
-    val arrowRecordBatch = data.collectAsArrow()
+    val arrowRecordBatch = indexData.collectAsArrow()
     assert(arrowRecordBatch.getLength > 0)
     assert(arrowRecordBatch.getNodes.size() > 0)
     arrowRecordBatch.close()
   }
 
   test("standard type conversion") {
+    collectAndValidate(indexData, "test-data/arrow/indexData-ints.json")
     collectAndValidate(largeAndSmallInts, "test-data/arrow/largeAndSmall-ints.json")
-    collectAndValidate(floatData, "test-data/arrow/floatData-single_precision.json")
     collectAndValidate(salary, "test-data/arrow/salary-doubles.json")
+  }
+
+  test("standard type nullable conversion") {
+    collectAndValidate(shortData, "test-data/arrow/shortData-16bit_ints-nullable.json")
+    collectAndValidate(intData, "test-data/arrow/intData-32bit_ints-nullable.json")
+    collectAndValidate(longData, "test-data/arrow/longData-64bit_ints-nullable.json")
+    collectAndValidate(floatData, "test-data/arrow/floatData-single_precision-nullable.json")
+    collectAndValidate(doubleData, "test-data/arrow/doubleData-double_precision-nullable.json")
+  }
+
+  test("mixed standard type nullable conversion") {
+    val mixedData = shortData.join(intData, "i").join(longData, "i").join(floatData, "i")
+      .join(doubleData, "i").sort("i")
+    collectAndValidate(mixedData, "test-data/arrow/mixedData-standard-nullable.json")
   }
 
   test("partitioned DataFrame") {
@@ -61,18 +80,19 @@ class ArrowSuite extends SharedSQLContext {
 
   test("nested type conversion") { }
 
-  test("array type conversion") {
-
-  }
+  test("array type conversion") { }
 
   test("mapped type conversion") { }
 
   test("other type conversion") {
+    // half-precision
     // byte type, or binary
     // allNulls
-
   }
 
+  test("floating-point NaN") { }
+
+  // Arrow currently supports single or double precision
   ignore("arbitrary precision floating point") {
     collectAndValidate(decimalData, "test-data/arrow/decimalData-BigDecimal.json")
   }
@@ -89,7 +109,28 @@ class ArrowSuite extends SharedSQLContext {
     collectAndValidate(nullStringsColOnly, "test-data/arrow/null-strings.json")
   }
 
-  test("negative tests") { }
+  test("empty frame collect") {
+    val emptyBatch = spark.emptyDataFrame.collectAsArrow()
+    assert(emptyBatch.getLength == 0)
+  }
+
+  test("negative tests") {
+
+    // Missing test file
+    intercept[NullPointerException] {
+      collectAndValidate(indexData, "test-data/arrow/missing-file")
+    }
+
+    // Different schema
+    intercept[IllegalArgumentException] {
+      collectAndValidate(shortData, "test-data/arrow/intData-32bit_ints-nullable.json")
+    }
+
+    // Different values
+    intercept[IllegalArgumentException] {
+      collectAndValidate(indexData.sort($"i".desc), "test-data/arrow/indexData-ints.json")
+    }
+  }
 
   /** Test that a converted DataFrame to Arrow record batch equals batch read from JSON file */
   private def collectAndValidate(df: DataFrame, arrowFile: String) {
@@ -111,13 +152,55 @@ class ArrowSuite extends SharedSQLContext {
     Validator.compareVectorSchemaRoot(arrowRoot, jsonRoot)
   }
 
+  protected lazy val indexData = Seq(1, 2, 3, 4, 5, 6).toDF("i")
+
+  protected lazy val shortData: DataFrame = {
+    spark.sparkContext.parallelize(
+      ShortData(1, 1, Some(1)) ::
+      ShortData(2, -1, None) ::
+      ShortData(3, 2, None) ::
+      ShortData(4, -2, Some(-2)) ::
+      ShortData(5, 32767, None) ::
+      ShortData(6, -32768, Some(-32768)) :: Nil).toDF()
+  }
+
+  protected lazy val intData: DataFrame = {
+    spark.sparkContext.parallelize(
+      IntData(1, 1, Some(1)) ::
+      IntData(2, -1, None) ::
+      IntData(3, 2, None) ::
+      IntData(4, -2, Some(-2)) ::
+      IntData(5, 2147483647, None) ::
+      IntData(6, -2147483648, Some(-2147483648)) :: Nil).toDF()
+  }
+
+  protected lazy val longData: DataFrame = {
+    spark.sparkContext.parallelize(
+      LongData(1, 1L, 1L) ::
+      LongData(2, -1L, null) ::
+      LongData(3, 2L, null) ::
+      LongData(4, -2, -2L) ::
+      LongData(5, 9223372036854775807L, null) ::
+      LongData(6, -9223372036854775808L, -9223372036854775808L) :: Nil).toDF()
+  }
+
   protected lazy val floatData: DataFrame = {
     spark.sparkContext.parallelize(
-      FloatData(Some(1), 1.0f) ::
-      FloatData(None, 2.0f) ::
-      FloatData(None, 0.01f) ::
-      FloatData(Some(2), 200.0f) ::
-      FloatData(None, 0.0001f) ::
-      FloatData(Some(3), 20000.0f) :: Nil).toDF()
+      FloatData(1, 1.0f, Some(1.1f)) ::
+      FloatData(2, 2.0f, None) ::
+      FloatData(3, 0.01f, None) ::
+      FloatData(4, 200.0f, Some(2.2f)) ::
+      FloatData(5, 0.0001f, None) ::
+      FloatData(6, 20000.0f, Some(3.3f)) :: Nil).toDF()
+  }
+
+  protected lazy val doubleData: DataFrame = {
+    spark.sparkContext.parallelize(
+      DoubleData(1, 1.0, Some(1.1)) ::
+      DoubleData(2, 2.0, None) ::
+      DoubleData(3, 0.01, None) ::
+      DoubleData(4, 200.0, Some(2.2)) ::
+      DoubleData(5, 0.0001, None) ::
+      DoubleData(6, 20000.0, Some(3.3)) :: Nil).toDF()
   }
 }


### PR DESCRIPTION
* Fixed bit-width of ShortType
* Added Python tests for use cases of `toPandas()`
* Added more type conversion tests for Scala conversion, including Arrow json data files
