### PR TITLE
Add support for date/timestamp/binary; Add more numbers to benchmark.…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2773,6 +2773,8 @@ class Dataset[T] private[sql](
     } catch {
       case e: Exception =>
         throw e
+    } finally {
+      recordBatch.close()
     }
 
     withNewExecutionId {

--- a/sql/core/src/test/resources/test-data/arrow/timestampData.json
+++ b/sql/core/src/test/resources/test-data/arrow/timestampData.json
@@ -1,0 +1,32 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "a_timestamp",
+                "type": {"name": "timestamp", "unit": "MILLISECOND"},
+                "nullable": true,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 64}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 2,
+            "columns": [
+                {
+                    "name": "a_timestamp",
+                    "count": 2,
+                    "VALIDITY": [1, 1],
+                    "DATA": [1365383415567, 1365426610789]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/ArrowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ArrowSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 import java.io.File
 import java.sql.{Date, Timestamp}
 import java.text.SimpleDateFormat
-import java.util.Locale
+import java.util.{Locale, TimeZone}
 
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.{VectorLoader, VectorSchemaRoot}
@@ -90,15 +90,28 @@ class ArrowSuite extends SharedSQLContext {
     collectAndValidate(lowerCaseData, "test-data/arrow/lowercase-strings.json")
   }
 
-  ignore("time and date conversion") {
-    val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
-    val d1 = new Date(sdf.parse("2015-04-08 13:10:15").getTime)
-    val d2 = new Date(sdf.parse("2015-04-08 13:10:15").getTime)
-    val ts1 = new Timestamp(sdf.parse("2013-04-08 01:10:15").getTime)
-    val ts2 = new Timestamp(sdf.parse("2013-04-08 13:10:10").getTime)
+  ignore("date conversion") {
+    val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+    val d1 = new Date(sdf.parse("2015-04-08 13:10:15.000").getTime)
+    val d2 = new Date(sdf.parse("2015-04-08 13:10:15.000").getTime)
+    val ts1 = new Timestamp(sdf.parse("2013-04-08 01:10:15.567").getTime)
+    val ts2 = new Timestamp(sdf.parse("2013-04-08 13:10:10.789").getTime)
     val dateTimeData = Seq((d1, sdf.format(d1), ts1), (d2, sdf.format(d2), ts2))
-      .toDF("a_date", "b_string", "c_timestamp")
+        .toDF("a_date", "b_string", "c_timestamp")
     collectAndValidate(dateTimeData, "test-data/arrow/datetimeData-strings.json")
+  }
+
+  test("timestamp conversion") {
+    val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS z", Locale.US)
+    val ts1 = new Timestamp(sdf.parse("2013-04-08 01:10:15.567 UTC").getTime)
+    val ts2 = new Timestamp(sdf.parse("2013-04-08 13:10:10.789 UTC").getTime)
+    val dateTimeData = Seq((ts1), (ts2)).toDF("a_timestamp")
+    collectAndValidate(dateTimeData, "test-data/arrow/timestampData.json")
+  }
+
+  // Arrow json reader doesn't support binary data
+  ignore("binary type conversion") {
+    collectAndValidate(binaryData, "test-data/arrow/binaryData.json")
   }
 
   test("nested type conversion") { }


### PR DESCRIPTION
…py; Fix memory leaking bug

## What changes were proposed in this pull request?
1. Support for date/timestamp/binary type
2. benchmark of internalRowsToArrowRecordBatch
3. Fix memory leaking bug in Arrow.scala

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
