### PR TITLE
[WIP] Arrow conversion at partitions

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -394,7 +394,7 @@ class DataFrame(object):
     @ignore_unicode_prefix
     @since(2.0)
     def collectAsArrow(self):
-        """Returns all the records as an ArrowRecordBatch
+        """Returns all records as list of deserialized ArrowPayloads
         """
         with SCCallSiteSync(self._sc) as css:
             port = self._jdf.collectAsArrowToPython()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1573,6 +1573,9 @@ class DataFrame(object):
 
         This is only available if Pandas is installed and available.
 
+        :param useArrow: Make use of Apache Arrow for conversion, pyarrow must be installed
+            on the calling Python process.
+
         .. note:: This method should only be used if the resulting Pandas's DataFrame is expected
             to be small, as all the data is loaded into the driver's memory.
 
@@ -1581,11 +1584,10 @@ class DataFrame(object):
         0    2  Alice
         1    5    Bob
         """
-        import pandas as pd
-
         if useArrow:
             return self.collectAsArrow().to_pandas()
         else:
+            import pandas as pd
             return pd.DataFrame.from_records(self.collect(), columns=self.columns)
 
     ##########################################################################################

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -398,7 +398,7 @@ class DataFrame(object):
         """
         with SCCallSiteSync(self._sc) as css:
             port = self._jdf.collectAsArrowToPython()
-        return list(_load_from_socket(port, ArrowSerializer()))[0]
+        return list(_load_from_socket(port, ArrowSerializer()))
 
     @ignore_unicode_prefix
     @since(2.0)
@@ -1585,7 +1585,10 @@ class DataFrame(object):
         1    5    Bob
         """
         if useArrow:
-            return self.collectAsArrow().to_pandas()
+            from pyarrow.table import concat_tables
+            tables = self.collectAsArrow()
+            table = concat_tables(tables)
+            return table.to_pandas()
         else:
             import pandas as pd
             return pd.DataFrame.from_records(self.collect(), columns=self.columns)

--- a/sql/core/src/main/scala/org/apache/spark/sql/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ArrowConverters.scala
@@ -159,7 +159,7 @@ private[sql] object ArrowConverters {
     val fieldAndBuf = columnWriters.map { writer =>
       writer.finish()
     }.unzip
-    val fieldNodes = fieldAndBuf._1.flatten
+    val fieldNodes = fieldAndBuf._1
     val buffers = fieldAndBuf._2.flatten
 
     val rowLength = if(fieldNodes.nonEmpty) fieldNodes.head.getLength else 0
@@ -209,7 +209,7 @@ private[sql] trait ColumnWriter {
    * Clear the column writer and return the ArrowFieldNode and ArrowBuf.
    * This should be called only once after all the data is written.
    */
-  def finish(): (Seq[ArrowFieldNode], Seq[ArrowBuf])
+  def finish(): (ArrowFieldNode, Array[ArrowBuf])
 }
 
 /**
@@ -243,11 +243,11 @@ private[sql] abstract class PrimitiveColumnWriter(
     count += 1
   }
 
-  override def finish(): (Seq[ArrowFieldNode], Seq[ArrowBuf]) = {
+  override def finish(): (ArrowFieldNode, Array[ArrowBuf]) = {
     valueMutator.setValueCount(count)
     val fieldNode = new ArrowFieldNode(count, nullCount)
-    val valueBuffers: Seq[ArrowBuf] = valueVector.getBuffers(true)
-    (List(fieldNode), valueBuffers)
+    val valueBuffers = valueVector.getBuffers(true)
+    (fieldNode, valueBuffers)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ArrowConverters.scala
@@ -86,19 +86,21 @@ private[sql] class ByteArrayReadableSeekableByteChannel(var byteArray: Array[Byt
 private[sql] abstract class ArrowPayload extends Iterator[ArrowRecordBatch]
 
 /**
+ * Build a payload from existing ArrowRecordBatches
+ */
+private[sql] class ArrowStaticPayload(batches: ArrowRecordBatch*) extends ArrowPayload {
+  private val iter = batches.iterator
+  override def next(): ArrowRecordBatch = iter.next()
+  override def hasNext: Boolean = iter.hasNext
+}
+
+/**
  * Class that wraps an Arrow RootAllocator used in conversion
  */
 private[sql] class ArrowConverters {
   private val _allocator = new RootAllocator(Long.MaxValue)
 
   private[sql] def allocator: RootAllocator = _allocator
-
-  private class ArrowStaticPayload(batches: ArrowRecordBatch*) extends ArrowPayload {
-    private val iter = batches.iterator
-
-    override def next(): ArrowRecordBatch = iter.next()
-    override def hasNext: Boolean = iter.hasNext
-  }
 
   def interalRowIterToPayload(rowIter: Iterator[InternalRow], schema: StructType): ArrowPayload = {
     val batch = ArrowConverters.internalRowIterToArrowBatch(rowIter, schema, allocator)

--- a/sql/core/src/main/scala/org/apache/spark/sql/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ArrowConverters.scala
@@ -227,13 +227,13 @@ private[sql] trait ColumnWriter {
  */
 private[sql] abstract class PrimitiveColumnWriter(
   val ordinal: Int,
-  protected val allocator: BaseAllocator)
+  val allocator: BaseAllocator)
     extends ColumnWriter {
-  protected def valueVector: BaseDataValueVector
-  protected def valueMutator: BaseMutator
+  def valueVector: BaseDataValueVector
+  def valueMutator: BaseMutator
 
-  protected def setNull(): Unit
-  protected def setValue(row: InternalRow, ordinal: Int): Unit
+  def setNull(): Unit
+  def setValue(row: InternalRow, ordinal: Int): Unit
 
   protected var count = 0
   protected var nullCount = 0
@@ -265,9 +265,9 @@ private[sql] class BooleanColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
   private def bool2int(b: Boolean): Int = if (b) 1 else 0
 
-  override protected val valueVector: NullableBitVector
+  override val valueVector: NullableBitVector
     = new NullableBitVector("BooleanValue", allocator)
-  override protected val valueMutator: NullableBitVector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableBitVector#Mutator = valueVector.getMutator
 
   override def setNull(): Unit = valueMutator.setNull(count)
   override def setValue(row: InternalRow, ordinal: Int): Unit
@@ -276,9 +276,9 @@ private[sql] class BooleanColumnWriter(ordinal: Int, allocator: BaseAllocator)
 
 private[sql] class ShortColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
-  override protected val valueVector: NullableSmallIntVector
+  override val valueVector: NullableSmallIntVector
     = new NullableSmallIntVector("ShortValue", allocator)
-  override protected val valueMutator: NullableSmallIntVector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableSmallIntVector#Mutator = valueVector.getMutator
 
   override def setNull(): Unit = valueMutator.setNull(count)
   override def setValue(row: InternalRow, ordinal: Int): Unit
@@ -287,9 +287,9 @@ private[sql] class ShortColumnWriter(ordinal: Int, allocator: BaseAllocator)
 
 private[sql] class IntegerColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
-  override protected val valueVector: NullableIntVector
+  override val valueVector: NullableIntVector
     = new NullableIntVector("IntValue", allocator)
-  override protected val valueMutator: NullableIntVector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableIntVector#Mutator = valueVector.getMutator
 
   override def setNull(): Unit = valueMutator.setNull(count)
   override def setValue(row: InternalRow, ordinal: Int): Unit
@@ -298,9 +298,9 @@ private[sql] class IntegerColumnWriter(ordinal: Int, allocator: BaseAllocator)
 
 private[sql] class LongColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
-  override protected val valueVector: NullableBigIntVector
+  override val valueVector: NullableBigIntVector
     = new NullableBigIntVector("LongValue", allocator)
-  override protected val valueMutator: NullableBigIntVector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableBigIntVector#Mutator = valueVector.getMutator
 
   override def setNull(): Unit = valueMutator.setNull(count)
   override def setValue(row: InternalRow, ordinal: Int): Unit
@@ -309,9 +309,9 @@ private[sql] class LongColumnWriter(ordinal: Int, allocator: BaseAllocator)
 
 private[sql] class FloatColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
-  override protected val valueVector: NullableFloat4Vector
+  override val valueVector: NullableFloat4Vector
     = new NullableFloat4Vector("FloatValue", allocator)
-  override protected val valueMutator: NullableFloat4Vector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableFloat4Vector#Mutator = valueVector.getMutator
 
   override def setNull(): Unit = valueMutator.setNull(count)
   override def setValue(row: InternalRow, ordinal: Int): Unit
@@ -320,9 +320,9 @@ private[sql] class FloatColumnWriter(ordinal: Int, allocator: BaseAllocator)
 
 private[sql] class DoubleColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
-  override protected val valueVector: NullableFloat8Vector
+  override val valueVector: NullableFloat8Vector
     = new NullableFloat8Vector("DoubleValue", allocator)
-  override protected val valueMutator: NullableFloat8Vector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableFloat8Vector#Mutator = valueVector.getMutator
 
   override def setNull(): Unit = valueMutator.setNull(count)
   override def setValue(row: InternalRow, ordinal: Int): Unit
@@ -331,9 +331,9 @@ private[sql] class DoubleColumnWriter(ordinal: Int, allocator: BaseAllocator)
 
 private[sql] class ByteColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
-  override protected val valueVector: NullableUInt1Vector
+  override val valueVector: NullableUInt1Vector
     = new NullableUInt1Vector("ByteValue", allocator)
-  override protected val valueMutator: NullableUInt1Vector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableUInt1Vector#Mutator = valueVector.getMutator
 
   override def setNull(): Unit = valueMutator.setNull(count)
   override def setValue(row: InternalRow, ordinal: Int): Unit
@@ -342,9 +342,9 @@ private[sql] class ByteColumnWriter(ordinal: Int, allocator: BaseAllocator)
 
 private[sql] class UTF8StringColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
-  override protected val valueVector: NullableVarBinaryVector
+  override val valueVector: NullableVarBinaryVector
     = new NullableVarBinaryVector("UTF8StringValue", allocator)
-  override protected val valueMutator: NullableVarBinaryVector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableVarBinaryVector#Mutator = valueVector.getMutator
 
   override def setNull(): Unit = valueMutator.setNull(count)
   override def setValue(row: InternalRow, ordinal: Int): Unit = {
@@ -355,9 +355,9 @@ private[sql] class UTF8StringColumnWriter(ordinal: Int, allocator: BaseAllocator
 
 private[sql] class BinaryColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
-  override protected val valueVector: NullableVarBinaryVector
+  override val valueVector: NullableVarBinaryVector
     = new NullableVarBinaryVector("BinaryValue", allocator)
-  override protected val valueMutator: NullableVarBinaryVector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableVarBinaryVector#Mutator = valueVector.getMutator
 
   override def setNull(): Unit = valueMutator.setNull(count)
   override def setValue(row: InternalRow, ordinal: Int): Unit = {
@@ -368,12 +368,12 @@ private[sql] class BinaryColumnWriter(ordinal: Int, allocator: BaseAllocator)
 
 private[sql] class DateColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
-  override protected val valueVector: NullableDateVector
+  override val valueVector: NullableDateVector
     = new NullableDateVector("DateValue", allocator)
-  override protected val valueMutator: NullableDateVector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableDateVector#Mutator = valueVector.getMutator
 
-  override protected def setNull(): Unit = valueMutator.setNull(count)
-  override protected def setValue(row: InternalRow, ordinal: Int): Unit = {
+  override def setNull(): Unit = valueMutator.setNull(count)
+  override def setValue(row: InternalRow, ordinal: Int): Unit = {
     // TODO: comment on diff btw value representations of date/timestamp
     valueMutator.setSafe(count, row.getInt(ordinal).toLong * 24 * 3600 * 1000)
   }
@@ -381,13 +381,12 @@ private[sql] class DateColumnWriter(ordinal: Int, allocator: BaseAllocator)
 
 private[sql] class TimeStampColumnWriter(ordinal: Int, allocator: BaseAllocator)
     extends PrimitiveColumnWriter(ordinal, allocator) {
-  override protected val valueVector: NullableTimeStampMicroVector
+  override val valueVector: NullableTimeStampMicroVector
     = new NullableTimeStampMicroVector("TimeStampValue", allocator)
-  override protected val valueMutator: NullableTimeStampMicroVector#Mutator = valueVector.getMutator
+  override val valueMutator: NullableTimeStampMicroVector#Mutator = valueVector.getMutator
 
-  override protected def setNull(): Unit = valueMutator.setNull(count)
-
-  override protected def setValue(row: InternalRow, ordinal: Int): Unit = {
+  override def setNull(): Unit = valueMutator.setNull(count)
+  override def setValue(row: InternalRow, ordinal: Int): Unit = {
     valueMutator.setSafe(count, row.getLong(ordinal) / 1000)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2375,8 +2375,8 @@ class Dataset[T] private[sql](
     val cnvtr = converter.getOrElse(new ArrowConverters)
     withNewExecutionId {
       try {
-        val collectedRows = queryExecution.executedPlan.executeCollect()
-        cnvtr.internalRowsToPayload(collectedRows, this.schema)
+        val rowIter = queryExecution.executedPlan.executeToIterator()
+        cnvtr.interalRowIterToPayload(rowIter, this.schema)
       } catch {
         case e: Exception =>
           throw e

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2380,7 +2380,7 @@ class Dataset[T] private[sql](
 
   def toArrowBatchBytes(): RDD[Array[Byte]] = {
     val schema_captured = this.schema
-    queryExecution.toRdd.mapPartitions { iter =>
+    queryExecution.toRdd.mapPartitionsInternal { iter =>
       val payload = new ArrowConverters().interalRowIterToPayload(iter, schema_captured)
       val payloadBytes = ArrowConverters.payloadToByteArray(payload, schema_captured)
       payload.foreach(_.close())

--- a/sql/core/src/test/resources/test-data/arrow/testData2-ints-part1.json
+++ b/sql/core/src/test/resources/test-data/arrow/testData2-ints-part1.json
@@ -1,0 +1,50 @@
+{
+    "schema": {
+        "fields": [
+            {
+                "name": "a",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            },
+            {
+                "name": "b",
+                "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                "nullable": false,
+                "children": [],
+                "typeLayout": {
+                    "vectors": [
+                        {"type": "VALIDITY", "typeBitWidth": 1},
+                        {"type": "DATA", "typeBitWidth": 32}
+                    ]
+                }
+            }
+        ]
+    },
+
+    "batches": [
+        {
+            "count": 3,
+            "columns": [
+                {
+                    "name": "a",
+                    "count": 3,
+                    "VALIDITY": [1, 1, 1],
+                    "DATA": [1, 1, 2]
+                },
+                {
+                    "name": "b",
+                    "count": 3,
+                    "VALIDITY": [1, 1, 1],
+                    "DATA": [1, 2, 1]
+                }
+            ]
+        }
+    ]
+}

--- a/sql/core/src/test/resources/test-data/arrow/testData2-ints-part2.json
+++ b/sql/core/src/test/resources/test-data/arrow/testData2-ints-part2.json
@@ -30,19 +30,19 @@
 
     "batches": [
         {
-            "count": 6,
+            "count": 3,
             "columns": [
                 {
                     "name": "a",
-                    "count": 6,
-                    "VALIDITY": [1, 1, 1, 1, 1, 1],
-                    "DATA": [1, 1, 2, 2, 3, 3]
+                    "count": 3,
+                    "VALIDITY": [1, 1, 1],
+                    "DATA": [2, 3, 3]
                 },
                 {
                     "name": "b",
-                    "count": 6,
-                    "VALIDITY": [1, 1, 1, 1, 1, 1],
-                    "DATA": [1, 2, 1, 2, 1, 2]
+                    "count": 3,
+                    "VALIDITY": [1, 1, 1],
+                    "DATA": [2, 1, 2]
                 }
             ]
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ArrowConvertersSuite.scala
@@ -170,17 +170,12 @@ class ArrowConvertersSuite extends SharedSQLContext {
     val jsonSchema = jsonReader.start()
     Validator.compareSchemas(arrowSchema, jsonSchema)
 
-    val arrowPayload = df.collectAsArrow(Some(converter))
+    // TODO: repartition because can only validate one batch
+    val arrowPayload = df.repartition(1).collectAsArrow(Some(converter))
     val arrowRoot = new VectorSchemaRoot(arrowSchema, converter.allocator)
     val vectorLoader = new VectorLoader(arrowRoot)
-    /*arrowPayload.foreach { pl =>
-      println("vector load")
-      vectorLoader.load(pl)
-    }*/
-    val arr = arrowPayload.toArray
-    vectorLoader.load(arr(0))
+    arrowPayload.foreach(vectorLoader.load)
     val jsonRoot = jsonReader.read()
-
     Validator.compareVectorSchemaRoot(arrowRoot, jsonRoot)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ArrowConvertersSuite.scala
@@ -173,7 +173,12 @@ class ArrowConvertersSuite extends SharedSQLContext {
     val arrowPayload = df.collectAsArrow(Some(converter))
     val arrowRoot = new VectorSchemaRoot(arrowSchema, converter.allocator)
     val vectorLoader = new VectorLoader(arrowRoot)
-    arrowPayload.foreach(vectorLoader.load)
+    /*arrowPayload.foreach { pl =>
+      println("vector load")
+      vectorLoader.load(pl)
+    }*/
+    val arr = arrowPayload.toArray
+    vectorLoader.load(arr(0))
     val jsonRoot = jsonReader.read()
 
     Validator.compareVectorSchemaRoot(arrowRoot, jsonRoot)

--- a/sql/core/src/test/scala/org/apache/spark/sql/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ArrowConvertersSuite.scala
@@ -46,6 +46,7 @@ class ArrowConvertersSuite extends SharedSQLContext {
   test("collect to arrow record batch") {
     val arrowPayload = indexData.collectAsArrow()
     assert(arrowPayload.nonEmpty)
+    // TODO - make sure only one partition?
     arrowPayload.foreach(arrowRecordBatch => assert(arrowRecordBatch.getLength > 0))
     arrowPayload.foreach(arrowRecordBatch => assert(arrowRecordBatch.getNodes.size() > 0))
     arrowPayload.foreach(arrowRecordBatch => arrowRecordBatch.close())

--- a/sql/core/src/test/scala/org/apache/spark/sql/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ArrowConvertersSuite.scala
@@ -124,8 +124,8 @@ class ArrowConvertersSuite extends SharedSQLContext {
 
   test("empty frame collect") {
     val arrowPayload = spark.emptyDataFrame.collectAsArrow()
-    assert(arrowPayload.nonEmpty)
-    arrowPayload.foreach(emptyBatch => assert(emptyBatch.getLength == 0))
+    assert(arrowPayload.isEmpty)
+    // TODO: test empty partitions
   }
 
   test("unsupported types") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Changed conversion to be iterator based, instead of `Array[InternalRows]`

Moved Dataset conversion to partitions, then collect as byte array

Added some pydocs

## How was this patch tested?
Passing tests now, need to test conversion with 1 partition to match json file
