### PR TITLE
Remove Date and Timestamp from supported types

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/ArrowConverters.scala
@@ -144,8 +144,9 @@ private[sql] object ArrowConverters {
       case ByteType => new ArrowType.Int(8, true)
       case StringType => ArrowType.Utf8.INSTANCE
       case BinaryType => ArrowType.Binary.INSTANCE
-      case DateType => ArrowType.Date.INSTANCE
-      case TimestampType => new ArrowType.Timestamp(TimeUnit.MILLISECOND)
+      // TODO: Enable Date and Timestamp type with Arrow 0.3
+      // case DateType => ArrowType.Date.INSTANCE
+      // case TimestampType => new ArrowType.Timestamp(TimeUnit.MILLISECOND)
       case _ => throw new UnsupportedOperationException(s"Unsupported data type: $dataType")
     }
   }
@@ -411,8 +412,9 @@ private[sql] object ColumnWriter {
       case ByteType => new ByteColumnWriter(ordinal, allocator)
       case StringType => new UTF8StringColumnWriter(ordinal, allocator)
       case BinaryType => new BinaryColumnWriter(ordinal, allocator)
-      case DateType => new DateColumnWriter(ordinal, allocator)
-      case TimestampType => new TimeStampColumnWriter(ordinal, allocator)
+      // TODO: Enable Date and Timestamp type with Arrow 0.3
+      // case DateType => new DateColumnWriter(ordinal, allocator)
+      // case TimestampType => new TimeStampColumnWriter(ordinal, allocator)
       case _ => throw new UnsupportedOperationException(s"Unsupported data type: $dataType")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ArrowConvertersSuite.scala
@@ -91,7 +91,7 @@ class ArrowConvertersSuite extends SharedSQLContext with BeforeAndAfterAll {
     collectAndValidate(byteData)
   }
 
-  test("timestamp conversion") {
+  ignore("timestamp conversion") {
     collectAndValidate(timestampData)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove Date and Timestamp from supported type until Arrow 0.3.0

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
