### PR TITLE
Use session local timezone for ArrowType.Timestamp.

### DIFF
--- a/python/pyspark/sql/tests.py
+++ b/python/pyspark/sql/tests.py
@@ -3005,10 +3005,9 @@ class ArrowTests(ReusedPySparkTestCase):
         tz = "America/Los_Angeles"
         os.environ["TZ"] = tz
         time.tzset()
-        cls.old_tz = cls.sc._jvm.org.apache.spark.sql.catalyst.util.DateTimeTestUtils\
-            .setDefaultTimeZone(tz)
 
         cls.spark = SparkSession(cls.sc)
+        cls.spark.conf.set("spark.sql.session.timeZone", tz)
         cls.spark.conf.set("spark.sql.execution.arrow.enable", "true")
         cls.schema = StructType([
             StructField("1_str_t", StringType(), True),
@@ -3026,8 +3025,8 @@ class ArrowTests(ReusedPySparkTestCase):
     def tearDownClass(cls):
         del os.environ["TZ"]
         time.tzset()
-        cls.sc._jvm.org.apache.spark.sql.catalyst.util.DateTimeTestUtils\
-            .setDefaultTimeZone(cls.old_tz)
+
+        cls.spark.stop()
 
     def assertFramesEqual(self, df_with_arrow, df_without):
         msg = ("DataFrame from Arrow is not equal" +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeTestUtils.scala
@@ -37,11 +37,4 @@ object DateTimeTestUtils {
       DateTimeUtils.resetThreadLocals()
     }
   }
-
-  def setDefaultTimeZone(id: String): String = {
-    val originalDefaultTimeZone = DateTimeUtils.defaultTimeZone().getID
-    DateTimeUtils.resetThreadLocals()
-    TimeZone.setDefault(TimeZone.getTimeZone(id))
-    originalDefaultTimeZone
-  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3090,9 +3090,11 @@ class Dataset[T] private[sql](
   private[sql] def toArrowPayload: RDD[ArrowPayload] = {
     val schemaCaptured = this.schema
     val maxRecordsPerBatch = sparkSession.sessionState.conf.arrowMaxRecordsPerBatch
+    val timeZoneId = Option(sparkSession.sessionState.conf.sessionLocalTimeZone)
     queryExecution.toRdd.mapPartitionsInternal { iter =>
       val context = TaskContext.get()
-      ArrowConverters.toPayloadIterator(iter, schemaCaptured, maxRecordsPerBatch, context)
+      ArrowConverters.toPayloadIterator(
+        iter, schemaCaptured, maxRecordsPerBatch, timeZoneId, context)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
@@ -60,9 +60,10 @@ private[sql] object ArrowConverters {
       rowIter: Iterator[InternalRow],
       schema: StructType,
       maxRecordsPerBatch: Int,
+      timeZoneId: Option[String],
       context: TaskContext): Iterator[ArrowPayload] = {
 
-    val arrowSchema = ArrowUtils.toArrowSchema(schema)
+    val arrowSchema = ArrowUtils.toArrowSchema(schema, timeZoneId)
     val allocator =
       ArrowUtils.rootAllocator.newChildAllocator("toPayloadIterator", 0, Long.MaxValue)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

I tried to use session local timezone for ArrowType.Timestamp.

## How was this patch tested?

Added some tests to `ArrowUtilsSuite`.