### PR TITLE
Adds separate runnable examples in Arrow-in-Spark documentation

### DIFF
--- a/docs/sql-programming-guide.md
+++ b/docs/sql-programming-guide.md
@@ -1667,25 +1667,8 @@ To use Arrow when executing these calls, users need to first set the Spark confi
 'spark.sql.execution.arrow.enabled' to 'true'. This is disabled by default.
 
 <div class="codetabs">
-<div data-lang="python"  markdown="1">
-{% highlight python %}
-
-import numpy as np
-import pandas as pd
-
-# Enable Arrow-based columnar data transfers
-spark.conf.set("spark.sql.execution.arrow.enabled", "true")
-
-# Generate a Pandas DataFrame
-pdf = pd.DataFrame(np.random.rand(100, 3))
-
-# Create a Spark DataFrame from a Pandas DataFrame using Arrow
-df = spark.createDataFrame(pdf)
-
-# Convert the Spark DataFrame back to a Pandas DataFrame using Arrow
-result_pdf = df.select("*").toPandas()
-
-{% endhighlight %}
+<div data-lang="python" markdown="1">
+{% include_example dataframe_with_arrow python/sql/arrow.py %}
 </div>
 </div>
 
@@ -1710,41 +1693,8 @@ and concat the results together to be a new column.
 The following example shows how to create a scalar pandas UDF that computes the product of 2 columns.
 
 <div class="codetabs">
-<div data-lang="python"  markdown="1">
-{% highlight python %}
-
-import pandas as pd
-from pyspark.sql.functions import col, pandas_udf
-from pyspark.sql.types import LongType
-
-# Declare the function and create the UDF
-def multiply_func(a, b):
-    return a * b
-
-multiply = pandas_udf(multiply_func, returnType=LongType())
-
-# The function for a pandas_udf should be able to execute with local Pandas data
-x = pd.Series([1, 2, 3])
-print(multiply_func(x, x))
-# 0    1
-# 1    4
-# 2    9
-# dtype: int64
-
-# Create a Spark DataFrame, 'spark' is an existing SparkSession
-df = spark.createDataFrame(pd.DataFrame(x, columns=["x"]))
-
-# Execute function as a Spark vectorized UDF
-df.select(multiply(col("x"), col("x"))).show()
-# +-------------------+
-# |multiply_func(x, x)|
-# +-------------------+
-# |                  1|
-# |                  4|
-# |                  9|
-# +-------------------+
-
-{% endhighlight %}
+<div data-lang="python" markdown="1">
+{% include_example scalar_pandas_udf python/sql/arrow.py %}
 </div>
 </div>
 
@@ -1763,33 +1713,8 @@ To use groupby apply, the user needs to define the following:
 The following example shows how to use groupby apply to subtract the mean from each value in the group.
 
 <div class="codetabs">
-<div data-lang="python"  markdown="1">
-{% highlight python %}
-
-from pyspark.sql.functions import pandas_udf, PandasUDFType
-
-df = spark.createDataFrame(
-    [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)],
-    ("id", "v"))
-
-@pandas_udf("id long, v double", PandasUDFType.GROUP_MAP)
-def substract_mean(pdf):
-    # pdf is a pandas.DataFrame
-    v = pdf.v
-    return pdf.assign(v=v - v.mean())
-
-df.groupby("id").apply(substract_mean).show()
-# +---+----+
-# | id|   v|
-# +---+----+
-# |  1|-0.5|
-# |  1| 0.5|
-# |  2|-3.0|
-# |  2|-1.0|
-# |  2| 4.0|
-# +---+----+
-
-{% endhighlight %}
+<div data-lang="python" markdown="1">
+{% include_example group_map_pandas_udf python/sql/arrow.py %}
 </div>
 </div>
 

--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -1,0 +1,125 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+A simple example demonstrating Arrow in Spark.
+Run with:
+  ./bin/spark-submit examples/src/main/python/sql/arrow.py
+"""
+
+from __future__ import print_function
+
+from pyspark.sql import SparkSession
+from pyspark.sql.utils import require_minimum_pandas_version, require_minimum_pyarrow_version
+
+require_minimum_pandas_version()
+require_minimum_pyarrow_version()
+
+
+def dataframe_with_arrow_example(spark):
+    # $example on:dataframe_with_arrow$
+    import numpy as np
+    import pandas as pd
+
+    # Enable Arrow-based columnar data transfers
+    spark.conf.set("spark.sql.execution.arrow.enabled", "true")
+
+    # Generate a Pandas DataFrame
+    pdf = pd.DataFrame(np.random.rand(100, 3))
+
+    # Create a Spark DataFrame from a Pandas DataFrame using Arrow
+    df = spark.createDataFrame(pdf)
+
+    # Convert the Spark DataFrame back to a Pandas DataFrame using Arrow
+    result_pdf = df.select("*").toPandas()
+    # $example off:dataframe_with_arrow$
+
+
+def scalar_pandas_udf_example(spark):
+    # $example on:scalar_pandas_udf$
+    import pandas as pd
+
+    from pyspark.sql.functions import col, pandas_udf
+    from pyspark.sql.types import LongType
+
+    # Declare the function and create the UDF
+    def multiply_func(a, b):
+        return a * b
+
+    multiply = pandas_udf(multiply_func, returnType=LongType())
+
+    # The function for a pandas_udf should be able to execute with local Pandas data
+    x = pd.Series([1, 2, 3])
+    print(multiply_func(x, x))
+    # 0    1
+    # 1    4
+    # 2    9
+    # dtype: int64
+
+    # Create a Spark DataFrame, 'spark' is an existing SparkSession
+    df = spark.createDataFrame(pd.DataFrame(x, columns=["x"]))
+
+    # Execute function as a Spark vectorized UDF
+    df.select(multiply(col("x"), col("x"))).show()
+    # +-------------------+
+    # |multiply_func(x, x)|
+    # +-------------------+
+    # |                  1|
+    # |                  4|
+    # |                  9|
+    # +-------------------+
+    # $example off:scalar_pandas_udf$
+
+
+def group_map_pandas_udf_example(spark):
+    # $example on:group_map_pandas_udf$
+    from pyspark.sql.functions import pandas_udf, PandasUDFType
+
+    df = spark.createDataFrame(
+        [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)],
+        ("id", "v"))
+
+    @pandas_udf("id long, v double", PandasUDFType.GROUP_MAP)
+    def substract_mean(pdf):
+        # pdf is a pandas.DataFrame
+        v = pdf.v
+        return pdf.assign(v=v - v.mean())
+
+    df.groupby("id").apply(substract_mean).show()
+    # +---+----+
+    # | id|   v|
+    # +---+----+
+    # |  1|-0.5|
+    # |  1| 0.5|
+    # |  2|-3.0|
+    # |  2|-1.0|
+    # |  2| 4.0|
+    # +---+----+
+    # $example off:group_map_pandas_udf$
+
+
+if __name__ == "__main__":
+    spark = SparkSession \
+        .builder \
+        .appName("Python Arrow-in-Spark example") \
+        .getOrCreate()
+
+    dataframe_with_arrow_example(spark)
+    scalar_pandas_udf_example(spark)
+    group_map_pandas_udf_example(spark)
+
+    spark.stop()


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds separate runnable examples in Arrow-in-Spark documentation:

**Before**

<img width="903" alt="2018-01-26 8 37 32" src="https://user-images.githubusercontent.com/6477701/35418311-e676eb9c-0274-11e8-8052-9a6720dd32b2.png">

**After**

<img width="942" alt="2018-01-26 8 38 28" src="https://user-images.githubusercontent.com/6477701/35418323-f1f0477a-0274-11e8-8f29-25e54b81c8b4.png">

**Before**

<img width="937" alt="2018-01-26 8 37 46" src="https://user-images.githubusercontent.com/6477701/35418317-ece7580e-0274-11e8-8381-5de0be46e2e5.png">

**After**

<img width="970" alt="2018-01-26 8 38 36" src="https://user-images.githubusercontent.com/6477701/35418325-f3f27c50-0274-11e8-845d-977f4d836456.png">

**Before**

<img width="929" alt="2018-01-26 8 37 52" src="https://user-images.githubusercontent.com/6477701/35418320-eeab3f70-0274-11e8-8f2a-53f2f00ac322.png">

**After**

<img width="953" alt="2018-01-26 8 38 45" src="https://user-images.githubusercontent.com/6477701/35418326-f5e1a0ea-0274-11e8-9f36-a061f5443ec4.png">


## How was this patch tested?


```
PYSPARK_PYTON=python2.7 ./bin/spark-submit examples/src/main/python/sql/arrow.py
PYSPARK_PYTON=python3.6 ./bin/spark-submit examples/src/main/python/sql/arrow.py
./dev/lint-python
```

I manually checked the documentation.
